### PR TITLE
Fix documentation & repository links on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 authors = ["Andy Barron <AndrewLBarron@gmail.com>"]
 
 description = "Read and write user-specific application data (in stable Rust)"
-documentation = "https://andybarron.github.io/preferences"
-repository = "https://docs.rs/preferences"
+documentation = "https://docs.rs/preferences"
+repository = "https://github.com/AndyBarron/preferences-rs"
 readme = "README.md"
 keywords = ["preferences", "user", "data", "persistent", "storage"]
 license = "MIT"


### PR DESCRIPTION
The *documentation* link at https://crates.io/crates/preferences raises 404 at the moment, while the *repository* one leads to docs - this is somewhat confusing :)