### PR TITLE
Fix a bug where last part of the key is discarded and replaced with default filename

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,17 +384,19 @@ mod tests {
     }
     #[test]
     fn test_save_load() {
-        let name1 = gen_test_name("multiple-save-load-1");
-        let name2 = gen_test_name("multiple-save-load-2");
-        let save_result1 = 1i32.save(&APP_INFO, &name1);
-        let save_result2 = 2i32.save(&APP_INFO, &name2);
-        assert!(save_result1.is_ok());
-        assert!(save_result2.is_ok());
-        let load_result1 = i32::load(&APP_INFO, &name1);
-        let load_result2 = i32::load(&APP_INFO, &name2);
-        assert!(load_result1.is_ok());
-        assert!(load_result2.is_ok());
-        assert_eq!(load_result1.unwrap(), 1);
-        assert_eq!(load_result2.unwrap(), 2);
+        let sample_map = gen_sample_prefs();
+        let sample_other: i32 = 4;
+        let name_map = gen_test_name("save-load-map");
+        let name_other = gen_test_name("save-load-other");
+        let save_map_result = sample_map.save(&APP_INFO, &name_map);
+        let save_other_result = sample_other.save(&APP_INFO, &name_other);
+        assert!(save_map_result.is_ok());
+        assert!(save_other_result.is_ok());
+        let load_map_result = PreferencesMap::load(&APP_INFO, &name_map);
+        let load_other_result = i32::load(&APP_INFO, &name_other);
+        assert!(load_map_result.is_ok());
+        assert!(load_other_result.is_ok());
+        assert_eq!(load_map_result.unwrap(), sample_map);
+        assert_eq!(load_other_result.unwrap(), sample_other);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,18 +384,6 @@ mod tests {
     }
     #[test]
     fn test_save_load() {
-        let name = gen_test_name("save-load");
-        let sample = gen_sample_prefs();
-        let save_result = sample.save(&APP_INFO, &name);
-        println!("Save result: {:?}", save_result);
-        assert!(save_result.is_ok());
-        let load_result = PreferencesMap::load(&APP_INFO, &name);
-        println!("Load result: {:?}", load_result);
-        assert!(load_result.is_ok());
-        assert_eq!(load_result.unwrap(), sample);
-    }
-    #[test]
-    fn test_multiple_save_load() {
         let name1 = gen_test_name("multiple-save-load-1");
         let name2 = gen_test_name("multiple-save-load-2");
         let save_result1 = 1i32.save(&APP_INFO, &name1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,7 @@ pub trait Preferences: Sized {
 fn compute_file_path<S: AsRef<str>>(app: &AppInfo, key: S) -> Result<PathBuf, PreferencesError> {
     let mut path = get_app_dir(DATA_TYPE, app, key.as_ref())?;
     let new_name = match path.file_name() {
-        Some(name) if name.is_empty() => {
+        Some(name) if !name.is_empty() => {
             let mut new_name = OsString::with_capacity(name.len() + PREFS_FILE_EXTENSION.len());
             new_name.push(name);
             new_name.push(PREFS_FILE_EXTENSION);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,4 +394,19 @@ mod tests {
         assert!(load_result.is_ok());
         assert_eq!(load_result.unwrap(), sample);
     }
+    #[test]
+    fn test_multiple_save_load() {
+        let name1 = gen_test_name("multiple-save-load-1");
+        let name2 = gen_test_name("multiple-save-load-2");
+        let save_result1 = 1i32.save(&APP_INFO, &name1);
+        let save_result2 = 2i32.save(&APP_INFO, &name2);
+        assert!(save_result1.is_ok());
+        assert!(save_result2.is_ok());
+        let load_result1 = i32::load(&APP_INFO, &name1);
+        let load_result2 = i32::load(&APP_INFO, &name2);
+        assert!(load_result1.is_ok());
+        assert!(load_result2.is_ok());
+        assert_eq!(load_result1.unwrap(), 1);
+        assert_eq!(load_result2.unwrap(), 2);
+    }
 }


### PR DESCRIPTION
Before 1.0.0, [this](https://github.com/AndyBarron/preferences-rs/blob/master/src/lib.rs#L321) line used to say

```rust
Some(name) if name.len() > 0 => {
```

With 1.0.0 it was changed to `if name.is_empty()` which caused the filename part of the path to be discarded instead of prepending it to `PREFS_FILE_EXTENSION`