### PR TITLE
Update app_dirs to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["preferences", "user", "data", "persistent", "storage"]
 license = "MIT"
 
 [dependencies]
-app_dirs = "^1.1.1"
+app_dirs = { package = "app_dirs2", version = "2.5" }
 serde = "^1.0.0"
 serde_json = "^1.0.0"
 


### PR DESCRIPTION
This new version replaces the decommissioned version of app_dirs, plus it adds other platforms, such as android